### PR TITLE
Add IAM checks to device.get and device.update

### DIFF
--- a/api/device/device.go
+++ b/api/device/device.go
@@ -211,26 +211,37 @@ func Get(ctx context.Context, p *GetParams) (*GetResult, error) {
 		return nil, ErrNotFound
 	}
 
+	if err := iam.InSite(ctx, r.SiteID); err != nil {
+		return nil, err
+	}
+
 	return &r, nil
 }
 
 // Update
 
 type UpdateParams struct {
-	ID    string  `json:"id"`
-	Name  *string `json:"name"`
-	Brand *string `json:"brand"`
-	Model *string `json:"model"`
+	ID       string  `json:"id"`
+	SiteID   string  `json:"siteId"`
+	Name     *string `json:"name"`
+	Tag      *string `json:"tag"`
+	Brand    *string `json:"brand"`
+	Model    *string `json:"model"`
+	IsActive *bool   `json:"isActive"`
 }
 
 func (p *UpdateParams) Valid() error {
 	v := validator.New()
 	v.Must(p.ID != "", "id is required")
+	v.Must(p.SiteID != "", "siteId is required")
 	return v.Error()
 }
 
 func Update(ctx context.Context, p *UpdateParams) (*struct{}, error) {
 	if err := p.Valid(); err != nil {
+		return nil, err
+	}
+	if err := iam.InSite(ctx, p.SiteID); err != nil {
 		return nil, err
 	}
 
@@ -239,15 +250,22 @@ func Update(ctx context.Context, p *UpdateParams) (*struct{}, error) {
 		if p.Name != nil {
 			b.Set("name").To(*p.Name)
 		}
+		if p.Tag != nil {
+			b.Set("tag").To(*p.Tag)
+		}
 		if p.Brand != nil {
 			b.Set("brand").To(*p.Brand)
 		}
 		if p.Model != nil {
 			b.Set("model").To(*p.Model)
 		}
+		if p.IsActive != nil {
+			b.Set("is_active").To(*p.IsActive)
+		}
 		b.Set("updated_at").ToRaw("NOW()")
 		b.Where(func(c pgstmt.Cond) {
 			c.Eq("id", p.ID)
+			c.Eq("site_id", p.SiteID)
 		})
 	}).ExecWith(ctx)
 	if err != nil {

--- a/api/device/device_test.go
+++ b/api/device/device_test.go
@@ -1,0 +1,211 @@
+package device
+
+import (
+	"testing"
+
+	"github.com/acoshift/pgsql/pgctx"
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anertic/anertic/api/auth"
+	"github.com/anertic/anertic/api/iam"
+	"github.com/anertic/anertic/pkg/tu"
+)
+
+func seedUser(t *testing.T, tc *tu.Context) string {
+	t.Helper()
+	ctx := tc.Ctx()
+	id := xid.New().String()
+	_, err := pgctx.Exec(ctx, `
+		insert into users (id, email, name, provider, provider_id)
+		values ($1, $2, $3, 'google', 'g-test')
+		on conflict (email) do nothing
+	`,
+		id,
+		id+"@test.com",
+		"Test User",
+	)
+	require.NoError(t, err)
+	return id
+}
+
+func seedSite(t *testing.T, tc *tu.Context, ownerID string) string {
+	t.Helper()
+	ctx := tc.Ctx()
+	id := xid.New().String()
+	_, err := pgctx.Exec(ctx, `
+		insert into sites (id, name) values ($1, $2)
+	`,
+		id,
+		"Test Site",
+	)
+	require.NoError(t, err)
+
+	_, err = pgctx.Exec(ctx, `
+		insert into site_members (site_id, user_id, role) values ($1, $2, 'owner')
+	`,
+		id,
+		ownerID,
+	)
+	require.NoError(t, err)
+	return id
+}
+
+func seedDevice(t *testing.T, tc *tu.Context, siteID string) string {
+	t.Helper()
+	ctx := tc.Ctx()
+	id := xid.New().String()
+	_, err := pgctx.Exec(ctx, `
+		insert into devices (id, site_id, name, type) values ($1, $2, $3, $4)
+	`,
+		id,
+		siteID,
+		"Test Device",
+		"meter",
+	)
+	require.NoError(t, err)
+	return id
+}
+
+func TestGet(t *testing.T) {
+	tc := tu.Setup()
+	defer tc.Teardown()
+
+	userID := seedUser(t, tc)
+	otherUserID := seedUser(t, tc)
+	siteID := seedSite(t, tc, userID)
+	deviceID := seedDevice(t, tc, siteID)
+
+	t.Run("member can get device", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+
+		r, err := Get(ctx, &GetParams{ID: deviceID})
+		require.NoError(t, err)
+		assert.Equal(t, deviceID, r.ID)
+		assert.Equal(t, siteID, r.SiteID)
+		assert.Equal(t, "Test Device", r.Name)
+		assert.Equal(t, "meter", r.Type)
+	})
+
+	t.Run("non-member gets forbidden", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), otherUserID)
+
+		_, err := Get(ctx, &GetParams{ID: deviceID})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, iam.ErrForbidden)
+	})
+
+	t.Run("missing id returns validation error", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+
+		_, err := Get(ctx, &GetParams{ID: ""})
+		require.Error(t, err)
+	})
+
+	t.Run("unknown id returns not found", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+
+		_, err := Get(ctx, &GetParams{ID: "nonexistent"})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	tc := tu.Setup()
+	defer tc.Teardown()
+
+	userID := seedUser(t, tc)
+	otherUserID := seedUser(t, tc)
+	siteID := seedSite(t, tc, userID)
+	deviceID := seedDevice(t, tc, siteID)
+
+	t.Run("member can update name", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+		name := "Updated Device"
+
+		_, err := Update(ctx, &UpdateParams{
+			ID:     deviceID,
+			SiteID: siteID,
+			Name:   &name,
+		})
+		require.NoError(t, err)
+
+		r, err := Get(ctx, &GetParams{ID: deviceID})
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Device", r.Name)
+	})
+
+	t.Run("member can update tag", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+		tag := "floor-2"
+
+		_, err := Update(ctx, &UpdateParams{
+			ID:     deviceID,
+			SiteID: siteID,
+			Tag:    &tag,
+		})
+		require.NoError(t, err)
+
+		r, err := Get(ctx, &GetParams{ID: deviceID})
+		require.NoError(t, err)
+		assert.Equal(t, "floor-2", r.Tag)
+	})
+
+	t.Run("member can update isActive", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+		isActive := false
+
+		_, err := Update(ctx, &UpdateParams{
+			ID:       deviceID,
+			SiteID:   siteID,
+			IsActive: &isActive,
+		})
+		require.NoError(t, err)
+
+		r, err := Get(ctx, &GetParams{ID: deviceID})
+		require.NoError(t, err)
+		assert.Equal(t, false, r.IsActive)
+	})
+
+	t.Run("partial update does not affect other fields", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+		brand := "ABB"
+
+		_, err := Update(ctx, &UpdateParams{
+			ID:     deviceID,
+			SiteID: siteID,
+			Brand:  &brand,
+		})
+		require.NoError(t, err)
+
+		r, err := Get(ctx, &GetParams{ID: deviceID})
+		require.NoError(t, err)
+		assert.Equal(t, "ABB", r.Brand)
+		assert.Equal(t, "Updated Device", r.Name)
+		assert.Equal(t, "floor-2", r.Tag)
+	})
+
+	t.Run("non-member gets forbidden", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), otherUserID)
+		name := "Hacked"
+
+		_, err := Update(ctx, &UpdateParams{
+			ID:     deviceID,
+			SiteID: siteID,
+			Name:   &name,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, iam.ErrForbidden)
+	})
+
+	t.Run("missing siteId returns validation error", func(t *testing.T) {
+		ctx := auth.WithAccountID(tc.Ctx(), userID)
+
+		_, err := Update(ctx, &UpdateParams{
+			ID: deviceID,
+		})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
- **device.get**: added `iam.InSite()` check after fetching — non-members get forbidden
- **device.update**: requires `siteId` param, checks IAM before updating, scopes WHERE to `site_id`
- Added `Tag *string` and `IsActive *bool` to `UpdateParams`
- Integration tests covering member access, forbidden, not-found, validation, and partial updates

## Test plan
- [x] All 10 new tests pass (`go test ./api/device/ -v`)
- [ ] Verify frontend sends `siteId` in `device.update` calls

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)