### PR TITLE
Refactor: Extract shared device types and config to lib

### DIFF
--- a/api/device/device.go
+++ b/api/device/device.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/acoshift/arpc/v2"
@@ -15,6 +16,8 @@ import (
 
 var (
 	ErrNotFound = arpc.NewErrorCode("device/not-found", "device not found")
+
+	validDeviceTypes = []string{"meter", "inverter", "solar_panel", "appliance"}
 )
 
 // List
@@ -119,6 +122,7 @@ func (p *CreateParams) Valid() error {
 	v.Must(p.SiteID != "", "siteId is required")
 	v.Must(p.Name != "", "name is required")
 	v.Must(p.Type != "", "type is required")
+	v.Must(slices.Contains(validDeviceTypes, p.Type), "type must be one of: meter, inverter, solar_panel, appliance")
 	return v.Error()
 }
 

--- a/web/app.anertic.com/app/components/meter-card.tsx
+++ b/web/app.anertic.com/app/components/meter-card.tsx
@@ -23,11 +23,12 @@ import { Label } from "~/components/ui/label"
 import { Separator } from "~/components/ui/separator"
 import { cn } from "~/lib/utils"
 import { api } from "~/lib/api"
+import { formatLastSeen, type MeterChannel } from "~/lib/device"
 
 // --- Types ---
 
+export type { MeterChannel }
 export type MeterProtocol = "mqtt" | "http"
-export type MeterChannel = "pv" | "grid" | "battery" | "ev" | "load"
 
 export interface MeterReading {
   metric: string
@@ -601,15 +602,4 @@ export function formatMetricLabel(metric: string): string {
   return labels[metric] || metric.replace(/_/g, " ")
 }
 
-export function formatLastSeen(lastSeenAt: string | null): string {
-  if (!lastSeenAt) return "Never"
-  const diff = Date.now() - new Date(lastSeenAt).getTime()
-  const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}
+export { formatLastSeen }

--- a/web/app.anertic.com/app/lib/device.ts
+++ b/web/app.anertic.com/app/lib/device.ts
@@ -1,0 +1,74 @@
+import {
+  RiCpuLine,
+  RiSunLine,
+  RiPlugLine,
+  RiFlashlightLine,
+  RiDashboard3Line,
+} from "@remixicon/react"
+
+// --- Types ---
+
+export type DeviceType = "inverter" | "solar_panel" | "appliance" | "meter"
+export type ConnectionStatus = "online" | "offline" | "degraded"
+export type MeterChannel = "pv" | "grid" | "battery" | "ev" | "load"
+
+export interface Device {
+  id: string
+  siteId: string
+  name: string
+  type: DeviceType
+  tag: string
+  brand: string
+  model: string
+  isActive: boolean
+  createdAt: string
+}
+
+// Extended device with connection/runtime fields (from list API)
+export interface DeviceListItem extends Device {
+  connectionStatus: ConnectionStatus
+  lastSeenAt: string | null
+  meterCount: number
+  dataPointsToday: number
+}
+
+// --- Config Maps ---
+
+export const DEVICE_TYPE_CONFIG: Record<
+  DeviceType,
+  { label: string; icon: typeof RiCpuLine; color: string; bg: string }
+> = {
+  inverter: { label: "Inverter", icon: RiFlashlightLine, color: "text-violet-600", bg: "bg-violet-500/10" },
+  solar_panel: { label: "Solar Panel", icon: RiSunLine, color: "text-amber-600", bg: "bg-amber-500/10" },
+  meter: { label: "Energy Meter", icon: RiDashboard3Line, color: "text-cyan-600", bg: "bg-cyan-500/10" },
+  appliance: { label: "Appliance", icon: RiPlugLine, color: "text-emerald-600", bg: "bg-emerald-500/10" },
+}
+
+export const STATUS_CONFIG: Record<ConnectionStatus, { label: string; color: string; dot: string }> = {
+  online: { label: "Online", color: "text-emerald-700", dot: "bg-emerald-500" },
+  offline: { label: "Offline", color: "text-muted-foreground", dot: "bg-muted-foreground/50" },
+  degraded: { label: "Degraded", color: "text-amber-700", dot: "bg-amber-500" },
+}
+
+// Suggested channels per device type
+export const DEVICE_CHANNEL_HINTS: Record<DeviceType, MeterChannel[]> = {
+  inverter: ["pv", "grid", "battery", "load"],
+  solar_panel: ["pv"],
+  appliance: ["load", "ev"],
+  meter: ["load", "grid"],
+}
+
+// --- Helpers ---
+
+export function formatLastSeen(lastSeenAt: string | null): string {
+  if (!lastSeenAt) return "Never"
+  const diff = Date.now() - new Date(lastSeenAt).getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}

--- a/web/app.anertic.com/app/routes/device-detail.tsx
+++ b/web/app.anertic.com/app/routes/device-detail.tsx
@@ -3,9 +3,6 @@ import { useNavigate, useParams } from "react-router"
 import useSWR from "swr"
 import {
   RiArrowLeftLine,
-  RiSunLine,
-  RiPlugLine,
-  RiFlashlightLine,
   RiSettings3Line,
   RiEditLine,
   RiDeleteBinLine,
@@ -40,65 +37,22 @@ import {
   formatPower,
   formatReadingValue,
   formatMetricLabel,
-  formatLastSeen,
   type Meter,
   type MeterReading,
   type MeterProtocol,
   type MeterChannel,
   CopyableField,
 } from "~/components/meter-card"
-
-// --- Types ---
-
-type DeviceType = "inverter" | "solar_panel" | "appliance" | "meter"
-
-interface Device {
-  id: string
-  siteId: string
-  name: string
-  type: DeviceType
-  tag: string
-  brand: string
-  model: string
-  isActive: boolean
-  createdAt: string
-}
-
-
-// --- Config ---
-
-const DEVICE_TYPE_CONFIG: Record<
-  DeviceType,
-  { label: string; icon: typeof RiPlugLine; color: string; bg: string }
-> = {
-  inverter: { label: "Inverter", icon: RiFlashlightLine, color: "text-violet-600", bg: "bg-violet-500/10" },
-  solar_panel: { label: "Solar Panel", icon: RiSunLine, color: "text-amber-600", bg: "bg-amber-500/10" },
-  meter: { label: "Energy Meter", icon: RiDashboard3Line, color: "text-cyan-600", bg: "bg-cyan-500/10" },
-  appliance: { label: "Appliance", icon: RiPlugLine, color: "text-emerald-600", bg: "bg-emerald-500/10" },
-}
-
-// Suggested channels per device type
-const DEVICE_CHANNEL_HINTS: Record<DeviceType, MeterChannel[]> = {
-  inverter: ["pv", "grid", "battery", "load"],
-  solar_panel: ["pv"],
-  appliance: ["load", "ev"],
-  meter: ["load", "grid"],
-}
+import {
+  DEVICE_TYPE_CONFIG,
+  DEVICE_CHANNEL_HINTS,
+  formatLastSeen,
+  type Device,
+  type DeviceType,
+} from "~/lib/device"
 
 
 // --- API Types ---
-
-interface DeviceGetResult {
-  id: string
-  siteId: string
-  name: string
-  type: DeviceType
-  tag: string
-  brand: string
-  model: string
-  isActive: boolean
-  createdAt: string
-}
 
 interface MeterListResult {
   items: Meter[]
@@ -117,7 +71,7 @@ export default function DeviceDetail() {
 
   const { data: device, isLoading: deviceLoading } = useSWR(
     deviceId ? ["device.get", deviceId] : null,
-    () => api<DeviceGetResult>("device.get", { id: deviceId }),
+    () => api<Device>("device.get", { id: deviceId }),
   )
 
   const { data: metersData, isLoading: metersLoading, mutate: mutateMeters } = useSWR(

--- a/web/app.anertic.com/app/routes/devices.tsx
+++ b/web/app.anertic.com/app/routes/devices.tsx
@@ -4,11 +4,8 @@ import {
   RiAddLine,
   RiSearchLine,
   RiCpuLine,
-  RiSunLine,
-  RiPlugLine,
   RiArrowRightSLine,
   RiLink,
-  RiFlashlightLine,
 } from "@remixicon/react"
 
 import { useSiteId } from "~/layouts/site"
@@ -19,31 +16,18 @@ import { Badge } from "~/components/ui/badge"
 import { Dialog, DialogContent } from "~/components/ui/dialog"
 import { Separator } from "~/components/ui/separator"
 import { cn } from "~/lib/utils"
-
-// --- Types ---
-
-interface Device {
-  id: string
-  siteId: string
-  name: string
-  type: DeviceType
-  tag: string
-  brand: string
-  model: string
-  isActive: boolean
-  connectionStatus: ConnectionStatus
-  lastSeenAt: string | null
-  meterCount: number
-  dataPointsToday: number
-  createdAt: string
-}
-
-type DeviceType = "inverter" | "solar_panel" | "appliance" | "meter"
-type ConnectionStatus = "online" | "offline" | "degraded"
+import {
+  DEVICE_TYPE_CONFIG,
+  STATUS_CONFIG,
+  formatLastSeen,
+  type DeviceType,
+  type ConnectionStatus,
+  type DeviceListItem,
+} from "~/lib/device"
 
 // --- Mock Data ---
 
-const MOCK_DEVICES: Device[] = [
+const MOCK_DEVICES: DeviceListItem[] = [
   {
     id: "dev_01",
     siteId: "site_01",
@@ -151,22 +135,6 @@ const MOCK_DEVICES: Device[] = [
   },
 ]
 
-const DEVICE_TYPE_CONFIG: Record<
-  DeviceType,
-  { label: string; icon: typeof RiCpuLine; color: string; bg: string }
-> = {
-  inverter: { label: "Inverter", icon: RiFlashlightLine, color: "text-violet-600", bg: "bg-violet-500/10" },
-  solar_panel: { label: "Solar Panel", icon: RiSunLine, color: "text-amber-600", bg: "bg-amber-500/10" },
-  meter: { label: "Meter", icon: RiCpuLine, color: "text-cyan-600", bg: "bg-cyan-500/10" },
-  appliance: { label: "Appliance", icon: RiPlugLine, color: "text-emerald-600", bg: "bg-emerald-500/10" },
-}
-
-const STATUS_CONFIG: Record<ConnectionStatus, { label: string; color: string; dot: string }> = {
-  online: { label: "Online", color: "text-emerald-700", dot: "bg-emerald-500" },
-  offline: { label: "Offline", color: "text-muted-foreground", dot: "bg-muted-foreground/50" },
-  degraded: { label: "Degraded", color: "text-amber-700", dot: "bg-amber-500" },
-}
-
 // --- Component ---
 
 export default function Devices() {
@@ -175,7 +143,7 @@ export default function Devices() {
   const [search, setSearch] = useState("")
   const [typeFilter, setTypeFilter] = useState<DeviceType | "all">("all")
   const [statusFilter, setStatusFilter] = useState<ConnectionStatus | "all">("all")
-  const [selectedDevice, setSelectedDevice] = useState<Device | null>(null)
+  const [selectedDevice, setSelectedDevice] = useState<DeviceListItem | null>(null)
 
   const devices = MOCK_DEVICES.filter((d) => {
     if (typeFilter !== "all" && d.type !== typeFilter) return false
@@ -355,7 +323,7 @@ function SummaryPill({
   )
 }
 
-function DeviceRow({ device, onClick }: { device: Device; onClick: () => void }) {
+function DeviceRow({ device, onClick }: { device: DeviceListItem; onClick: () => void }) {
   const typeConfig = DEVICE_TYPE_CONFIG[device.type]
   const TypeIcon = typeConfig.icon
   const statusConfig = STATUS_CONFIG[device.connectionStatus]
@@ -403,7 +371,7 @@ function DeviceRow({ device, onClick }: { device: Device; onClick: () => void })
   )
 }
 
-function DeviceQuickView({ device }: { device: Device }) {
+function DeviceQuickView({ device }: { device: DeviceListItem }) {
   const typeConfig = DEVICE_TYPE_CONFIG[device.type]
   const TypeIcon = typeConfig.icon
   const statusConfig = STATUS_CONFIG[device.connectionStatus]
@@ -472,15 +440,3 @@ function MetricBox({ label, value, color }: { label: string; value: string; colo
   )
 }
 
-function formatLastSeen(lastSeenAt: string | null): string {
-  if (!lastSeenAt) return "Never"
-  const diff = Date.now() - new Date(lastSeenAt).getTime()
-  const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}


### PR DESCRIPTION
## Summary
Extract device-related types, configuration maps, and utility functions into a centralized library module to reduce duplication and improve maintainability.

## Changes

### New File
- **`web/app.anertic.com/app/lib/device.ts`**: New shared device library containing:
  - Types: `DeviceType`, `ConnectionStatus`, `MeterChannel`, `Device`, `DeviceListItem`
  - Configuration maps: `DEVICE_TYPE_CONFIG`, `STATUS_CONFIG`, `DEVICE_CHANNEL_HINTS`
  - Utility: `formatLastSeen()` helper function

### Updated Files
- **`meter-card.tsx`**: Remove `formatLastSeen()` implementation, import from lib; re-export `MeterChannel` type
- **`device-detail.tsx`**: Import types and configs from lib instead of defining locally
- **`devices.tsx`**: Import types and configs from lib; use `DeviceListItem` type for device list
- **`api/device/device.go`**: Add validation for device type against allowed values

## Benefits
- Single source of truth for device types and configurations
- Eliminates code duplication across components
- Improves type safety and consistency