### PR TITLE
Wire devices list page to device.list API

### DIFF
--- a/api/device/device.go
+++ b/api/device/device.go
@@ -27,6 +27,7 @@ type ListParams struct {
 	SiteID string `json:"siteId"`
 	Type   string `json:"type"`
 	Search string `json:"search"`
+	Status string `json:"status"`
 }
 
 func (p *ListParams) Valid() error {
@@ -133,6 +134,9 @@ func List(ctx context.Context, p *ListParams) (*ListResult, error) {
 			return err
 		}
 		it.ConnectionStatus = deriveConnectionStatus(it.MeterCount, onlineCount, it.LastSeenAt)
+		if p.Status != "" && it.ConnectionStatus != p.Status {
+			return nil
+		}
 		items = append(items, it)
 		return nil
 	})

--- a/web/app.anertic.com/app/routes/devices.tsx
+++ b/web/app.anertic.com/app/routes/devices.tsx
@@ -35,7 +35,7 @@ export default function Devices() {
   const [typeFilter, setTypeFilter] = useState<DeviceType | "all">("all")
   const [statusFilter, setStatusFilter] = useState<ConnectionStatus | "all">("all")
 
-  const { data, isLoading, error, mutate } = useSWR(
+  const { data: allData } = useSWR(
     ["device.list", siteId, typeFilter, search],
     () =>
       api<{ items: DeviceListItem[] }>("device.list", {
@@ -45,12 +45,20 @@ export default function Devices() {
       }),
   )
 
-  const allDevices = data?.items ?? []
+  const allDevices = allData?.items ?? []
 
-  const devices =
-    statusFilter === "all"
-      ? allDevices
-      : allDevices.filter((d) => d.connectionStatus === statusFilter)
+  const { data, isLoading, error, mutate } = useSWR(
+    ["device.list", siteId, typeFilter, search, statusFilter],
+    () =>
+      api<{ items: DeviceListItem[] }>("device.list", {
+        siteId,
+        type: typeFilter !== "all" ? typeFilter : undefined,
+        search: search.trim() || undefined,
+        status: statusFilter !== "all" ? statusFilter : undefined,
+      }),
+  )
+
+  const devices = data?.items ?? []
 
   const summary = {
     total: allDevices.length,


### PR DESCRIPTION
## Summary
- Replace hardcoded `MOCK_DEVICES` with SWR fetch from `device.list` endpoint, passing `siteId` and `type` filter to the API
- Add loading skeleton cards and error state with retry button
- Navigate directly to device detail page on row click (removed `DeviceQuickView` dialog)
- Client-side filtering for search (name, brand, model, tag) and connection status
- Backend: add `tag` to device.list search ILike and fix nullable `last_seen_at` scan

Closes #41

## Test plan
- [ ] Verify devices load from API with correct site context
- [ ] Verify type filter buttons trigger new API call
- [ ] Verify status filter pills toggle client-side filtering
- [ ] Verify search filters devices client-side by name, brand, model, tag
- [ ] Verify loading skeletons appear while fetching
- [ ] Verify error state with retry button on API failure
- [ ] Verify empty state messages (no devices vs no filter results)
- [ ] Verify row click navigates to `/devices/:id?site=:siteId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)