### PR TITLE
Fix duplicate ev_authorization_tags constraint on fresh DB

### DIFF
--- a/schema/0005_auth_charger_scope.sql
+++ b/schema/0005_auth_charger_scope.sql
@@ -1,13 +1,2 @@
--- Add charger-scoped authorization: NULL = global, set = scoped to specific charger
-alter table ev_authorization_tags
-    add column if not exists charger_id varchar(20) references ev_chargers (id);
-
--- drop old unique constraint on id_tag alone, replace with (charger_id, id_tag)
-alter table ev_authorization_tags
-    drop constraint if exists ev_authorization_tags_id_tag_key;
-
-alter table ev_authorization_tags
-    add constraint ev_authorization_tags_charger_id_tag_key unique (charger_id, id_tag);
-
-create index if not exists idx_ev_authorization_tags_charger
-    on ev_authorization_tags (charger_id) where charger_id is not null;
+-- charger-scoped authorization is now part of 0004_ev.sql (charger_id column + unique constraint)
+-- this migration is intentionally empty as the schema was consolidated

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,64 @@
+package schema_test
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anertic/anertic/schema"
+)
+
+func setupDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dbSource := os.Getenv("TEST_DB_URL")
+	if dbSource == "" {
+		t.Skip("TEST_DB_URL env required")
+	}
+
+	n, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	require.NoError(t, err)
+	dbName := fmt.Sprintf("test_schema_%d", n.Int64())
+
+	pDB, err := sql.Open("postgres", fmt.Sprintf(dbSource, "postgres"))
+	require.NoError(t, err)
+
+	_, err = pDB.Exec(`create database ` + dbName)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		pDB.Exec(`drop database if exists ` + dbName)
+		pDB.Close()
+	})
+
+	db, err := sql.Open("postgres", fmt.Sprintf(dbSource, dbName))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func TestMigrate(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	t.Run("first run", func(t *testing.T) {
+		err := schema.Migrate(ctx, db)
+		require.NoError(t, err)
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		err := schema.Migrate(ctx, db)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
- Empty `schema/0005_auth_charger_scope.sql` since `0004_ev.sql` already defines the `charger_id` column and `unique(charger_id, id_tag)` constraint inline — the duplicate `ADD CONSTRAINT` caused `pq: relation "ev_authorization_tags_charger_id_tag_key" already exists` on startup
- Add `schema.Migrate` idempotency test to catch this class of issue

## Test plan
- [x] `go test ./schema/` passes — verifies first run and idempotent re-run
- [ ] Fresh `make dev-up && make run-api` starts without constraint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)