### PR TITLE
OCPP 1.6: Implement Reservation profile

### DIFF
--- a/api/charger/reservation.go
+++ b/api/charger/reservation.go
@@ -1,0 +1,296 @@
+package charger
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/acoshift/pgsql"
+	"github.com/acoshift/pgsql/pgctx"
+	"github.com/acoshift/pgsql/pgstmt"
+	"github.com/moonrhythm/validator"
+	"github.com/rs/xid"
+
+	"github.com/anertic/anertic/api/iam"
+	"github.com/anertic/anertic/pkg/ocpp"
+)
+
+// ReserveNow
+
+type ReserveNowParams struct {
+	ID            string    `json:"id"`
+	ConnectorID   int       `json:"connectorId"`
+	ExpiryDate    time.Time `json:"expiryDate"`
+	IdTag         string    `json:"idTag"`
+	ParentIdTag   string    `json:"parentIdTag"`
+	ReservationID int       `json:"reservationId"`
+}
+
+func (p *ReserveNowParams) Valid() error {
+	v := validator.New()
+	v.Must(p.ID != "", "id is required")
+	v.Must(p.ConnectorID >= 0, "connectorId must be >= 0")
+	v.Must(!p.ExpiryDate.IsZero(), "expiryDate is required")
+	v.Must(p.ExpiryDate.After(time.Now()), "expiryDate must be in the future")
+	v.Must(p.IdTag != "", "idTag is required")
+	v.Must(p.ReservationID > 0, "reservationId must be > 0")
+	return v.Error()
+}
+
+type ReserveNowResult struct {
+	ID string `json:"id"`
+}
+
+func ReserveNow(ctx context.Context, p *ReserveNowParams) (*ReserveNowResult, error) {
+	if err := p.Valid(); err != nil {
+		return nil, err
+	}
+
+	var chargePointID, siteID, chargerID string
+	err := pgctx.QueryRow(ctx, `
+		select
+			charge_point_id,
+			site_id,
+			id
+		from ev_chargers
+		where id = $1
+	`, p.ID).Scan(
+		&chargePointID,
+		&siteID,
+		&chargerID,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err := iam.InSite(ctx, siteID); err != nil {
+		return nil, err
+	}
+
+	recordID := xid.New().String()
+	_, err = pgctx.Exec(ctx, `
+		insert into ev_reservations (
+			id,
+			charger_id,
+			connector_id,
+			reservation_id,
+			id_tag,
+			parent_id_tag,
+			expiry_date,
+			status
+		) values ($1, $2, $3, $4, $5, $6, $7, 'Reserved')
+		on conflict (charger_id, reservation_id) do update set
+			connector_id = excluded.connector_id,
+			id_tag = excluded.id_tag,
+			parent_id_tag = excluded.parent_id_tag,
+			expiry_date = excluded.expiry_date,
+			status = 'Reserved',
+			updated_at = now()
+	`,
+		recordID,
+		chargerID,
+		p.ConnectorID,
+		p.ReservationID,
+		p.IdTag,
+		nullableString(p.ParentIdTag),
+		p.ExpiryDate,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	type reserveNowPayload struct {
+		ConnectorID   int    `json:"connectorId"`
+		ExpiryDate    string `json:"expiryDate"`
+		IdTag         string `json:"idTag"`
+		ParentIdTag   string `json:"parentIdTag,omitempty"`
+		ReservationID int    `json:"reservationId"`
+	}
+
+	pl := reserveNowPayload{
+		ConnectorID:   p.ConnectorID,
+		ExpiryDate:    p.ExpiryDate.UTC().Format(time.RFC3339),
+		IdTag:         p.IdTag,
+		ReservationID: p.ReservationID,
+	}
+	if p.ParentIdTag != "" {
+		pl.ParentIdTag = p.ParentIdTag
+	}
+
+	payload, err := json.Marshal(pl)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ocpp.SendCommand(ctx, chargePointID, "ReserveNow", payload); err != nil {
+		return nil, err
+	}
+
+	return &ReserveNowResult{ID: recordID}, nil
+}
+
+// CancelReservation
+
+type CancelReservationParams struct {
+	ID            string `json:"id"`
+	ReservationID int    `json:"reservationId"`
+}
+
+func (p *CancelReservationParams) Valid() error {
+	v := validator.New()
+	v.Must(p.ID != "", "id is required")
+	v.Must(p.ReservationID > 0, "reservationId must be > 0")
+	return v.Error()
+}
+
+type CancelReservationResult struct{}
+
+func CancelReservation(ctx context.Context, p *CancelReservationParams) (*CancelReservationResult, error) {
+	if err := p.Valid(); err != nil {
+		return nil, err
+	}
+
+	var chargePointID, siteID string
+	err := pgctx.QueryRow(ctx, `
+		select
+			charge_point_id,
+			site_id
+		from ev_chargers
+		where id = $1
+	`, p.ID).Scan(
+		&chargePointID,
+		&siteID,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err := iam.InSite(ctx, siteID); err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(struct {
+		ReservationID int `json:"reservationId"`
+	}{
+		ReservationID: p.ReservationID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ocpp.SendCommand(ctx, chargePointID, "CancelReservation", payload); err != nil {
+		return nil, err
+	}
+
+	return &CancelReservationResult{}, nil
+}
+
+// ListReservations
+
+type ListReservationsParams struct {
+	ID string `json:"id"`
+}
+
+func (p *ListReservationsParams) Valid() error {
+	v := validator.New()
+	v.Must(p.ID != "", "id is required")
+	return v.Error()
+}
+
+type ReservationItem struct {
+	ID            string    `json:"id"`
+	ConnectorID   int       `json:"connectorId"`
+	ReservationID int       `json:"reservationId"`
+	IdTag         string    `json:"idTag"`
+	ParentIdTag   string    `json:"parentIdTag"`
+	ExpiryDate    time.Time `json:"expiryDate"`
+	Status        string    `json:"status"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
+type ListReservationsResult struct {
+	Items []ReservationItem `json:"items"`
+}
+
+func ListReservations(ctx context.Context, p *ListReservationsParams) (*ListReservationsResult, error) {
+	if err := p.Valid(); err != nil {
+		return nil, err
+	}
+
+	var siteID string
+	err := pgctx.QueryRow(ctx, `
+		select site_id
+		from ev_chargers
+		where id = $1
+	`, p.ID).Scan(&siteID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err := iam.InSite(ctx, siteID); err != nil {
+		return nil, err
+	}
+
+	items := make([]ReservationItem, 0)
+	err = pgstmt.Select(func(b pgstmt.SelectStatement) {
+		b.Columns(
+			"r.id",
+			"r.connector_id",
+			"r.reservation_id",
+			"r.id_tag",
+			"r.parent_id_tag",
+			"r.expiry_date",
+			"r.status",
+			"r.created_at",
+			"r.updated_at",
+		)
+		b.From("ev_reservations r")
+		b.Where(func(c pgstmt.Cond) {
+			c.Eq("r.charger_id", p.ID)
+		})
+		b.OrderBy("r.created_at DESC")
+	}).IterWith(ctx, func(scan pgsql.Scanner) error {
+		var it ReservationItem
+		if err := scan(
+			&it.ID,
+			&it.ConnectorID,
+			&it.ReservationID,
+			&it.IdTag,
+			pgsql.NullString(&it.ParentIdTag),
+			&it.ExpiryDate,
+			&it.Status,
+			&it.CreatedAt,
+			&it.UpdatedAt,
+		); err != nil {
+			return err
+		}
+		items = append(items, it)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ListReservationsResult{Items: items}, nil
+}
+
+// nullableString returns nil if s is empty, or a pointer to s otherwise.
+// Used to store optional string fields as NULL in the database.
+func nullableString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/api/handler.go
+++ b/api/handler.go
@@ -114,6 +114,9 @@ func Mount(mux *httpmux.Mux, am *arpc.Manager) {
 	a.Handle("POST /charger.getDiagnostics", am.Handler(charger.GetDiagnostics))
 	a.Handle("POST /charger.getLocalListVersion", am.Handler(charger.GetLocalListVersion))
 	a.Handle("POST /charger.sendLocalList", am.Handler(charger.SendLocalList))
+	a.Handle("POST /charger.reserveNow", am.Handler(charger.ReserveNow))
+	a.Handle("POST /charger.cancelReservation", am.Handler(charger.CancelReservation))
+	a.Handle("POST /charger.listReservations", am.Handler(charger.ListReservations))
 
 	// Connectors
 	a.Handle("POST /connector.list", am.Handler(connector.List))

--- a/ocpp/hub.go
+++ b/ocpp/hub.go
@@ -276,6 +276,71 @@ func (h *Hub) HandleResponse(ctx context.Context, chargePointID string, action s
 			slog.ErrorContext(ctx, "failed to update get_diagnostics_status", "error", err, "chargePointID", chargePointID)
 		}
 		slog.InfoContext(ctx, "GetDiagnostics response", "chargePointID", chargePointID)
+
+	case "ReserveNow":
+		var resp struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(responsePayload, &resp); err != nil {
+			slog.ErrorContext(ctx, "failed to parse ReserveNow response", "error", err, "chargePointID", chargePointID)
+			return
+		}
+		var req struct {
+			ReservationID int `json:"reservationId"`
+		}
+		if err := json.Unmarshal(requestPayload, &req); err != nil {
+			slog.ErrorContext(ctx, "failed to parse ReserveNow request payload", "error", err, "chargePointID", chargePointID)
+			return
+		}
+		if resp.Status != "Accepted" {
+			// mark reservation as cancelled if charger rejected it
+			_, err := pgctx.Exec(ctx, `
+				update ev_reservations
+				set status = 'Cancelled',
+				    updated_at = now()
+				where charger_id = (select id from ev_chargers where charge_point_id = $1)
+				  and reservation_id = $2
+				  and status = 'Reserved'
+			`, chargePointID, req.ReservationID)
+			if err != nil {
+				slog.ErrorContext(ctx, "failed to cancel rejected reservation", "error", err, "chargePointID", chargePointID)
+			}
+			slog.WarnContext(ctx, "ReserveNow not accepted by charger", "chargePointID", chargePointID, "status", resp.Status, "reservationId", req.ReservationID)
+			return
+		}
+		slog.InfoContext(ctx, "ReserveNow accepted by charger", "chargePointID", chargePointID, "reservationId", req.ReservationID, "status", resp.Status)
+
+	case "CancelReservation":
+		var resp struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(responsePayload, &resp); err != nil {
+			slog.ErrorContext(ctx, "failed to parse CancelReservation response", "error", err, "chargePointID", chargePointID)
+			return
+		}
+		var req struct {
+			ReservationID int `json:"reservationId"`
+		}
+		if err := json.Unmarshal(requestPayload, &req); err != nil {
+			slog.ErrorContext(ctx, "failed to parse CancelReservation request payload", "error", err, "chargePointID", chargePointID)
+			return
+		}
+		if resp.Status != "Accepted" {
+			slog.WarnContext(ctx, "CancelReservation not accepted by charger", "chargePointID", chargePointID, "status", resp.Status, "reservationId", req.ReservationID)
+			return
+		}
+		_, err := pgctx.Exec(ctx, `
+			update ev_reservations
+			set status = 'Cancelled',
+			    updated_at = now()
+			where charger_id = (select id from ev_chargers where charge_point_id = $1)
+			  and reservation_id = $2
+			  and status = 'Reserved'
+		`, chargePointID, req.ReservationID)
+		if err != nil {
+			slog.ErrorContext(ctx, "failed to update reservation status after cancel", "error", err, "chargePointID", chargePointID)
+		}
+		slog.InfoContext(ctx, "CancelReservation accepted by charger", "chargePointID", chargePointID, "reservationId", req.ReservationID)
 	}
 }
 

--- a/ocpp/v16/reservation/reservation.go
+++ b/ocpp/v16/reservation/reservation.go
@@ -1,0 +1,9 @@
+package reservation
+
+// ReserveNow and CancelReservation are CSMS→CP commands only.
+// There are no inbound Call messages from the charge point for the Reservation profile.
+// Responses are handled in ocpp.Hub.HandleResponse.
+//
+// OCPP 1.6 Reservation Profile status values:
+//   ReserveNow.conf:       Accepted, Faulted, Occupied, Rejected, Unavailable
+//   CancelReservation.conf: Accepted, Rejected


### PR DESCRIPTION
Closes #11

## Summary
- Add **ReserveNow** and **CancelReservation** CSMS→CP commands via Redis pub/sub to charge points
- Add **ListReservations** API endpoint to query reservation history per charger
- Handle charger responses in `ocpp.Hub.HandleResponse` — updates reservation status to `Cancelled` if charger rejects `ReserveNow` or confirms `CancelReservation`
- Reservation data persisted in existing `ev_reservations` table with upsert on `(charger_id, reservation_id)`

## Migration
No schema changes needed — `ev_reservations` table already exists in `schema/0004_ev.sql`.

## Changes
- `api/charger/reservation.go` — New handlers: `ReserveNow`, `CancelReservation`, `ListReservations` with validation, IAM checks, and OCPP command dispatch
- `api/handler.go` — Register three new routes: `charger.reserveNow`, `charger.cancelReservation`, `charger.listReservations`
- `ocpp/hub.go` — Add `ReserveNow` and `CancelReservation` response handling cases in `HandleResponse`
- `ocpp/v16/reservation/reservation.go` — Package documentation (Reservation profile is CSMS→CP only, no inbound Call handlers needed)

## Test plan
- [ ] Send `charger.reserveNow` with valid charger ID, connector, idTag, expiryDate, and reservationId — verify reservation record created and OCPP command dispatched
- [ ] Send `charger.reserveNow` with expired date — verify validation error
- [ ] Send `charger.cancelReservation` — verify OCPP command dispatched and reservation status updated on accepted response
- [ ] Send `charger.listReservations` — verify returns reservation history for charger
- [ ] Verify charger rejection of ReserveNow marks reservation as Cancelled in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)